### PR TITLE
remove space(zenkaku) / partial notice

### DIFF
--- a/app/views/admin/customers/_form.html.slim
+++ b/app/views/admin/customers/_form.html.slim
@@ -39,7 +39,6 @@
             | メールアドレス
           td
             = f.email_field :email
-          td
 
         tr
           th

--- a/app/views/admin/genres/_error.html.slim
+++ b/app/views/admin/genres/_error.html.slim
@@ -1,5 +1,0 @@
-.row
-  - if genre.errors.any?
-    .alert.alert-danger.text-center
-      - genre.errors.full_messages.each do |message|
-        = message

--- a/app/views/admin/genres/_form.html.slim
+++ b/app/views/admin/genres/_form.html.slim
@@ -1,6 +1,5 @@
 = form_for(genre, url: url) do |f|
   = f.label :ジャンル
-  | 　
   = f.text_field :name
   = f.radio_button :is_valid, :true
   = f.label :is_valid, "有効", {value: :true, style: "display: inline-block;"}

--- a/app/views/admin/genres/edit.html.slim
+++ b/app/views/admin/genres/edit.html.slim
@@ -1,4 +1,4 @@
-= render 'error', genre: @genre
+= render 'layouts/error', obj: @genre
 .container
   .row
     .col-lg-3

--- a/app/views/admin/genres/index.html.slim
+++ b/app/views/admin/genres/index.html.slim
@@ -1,4 +1,4 @@
-= render 'error', genre: @genre
+= render 'layouts/error', obj: @genre
 .container
   .row
     .col-lg-3

--- a/app/views/admin/home/top.html.slim
+++ b/app/views/admin/home/top.html.slim
@@ -1,6 +1,3 @@
-- if flash[:notice]
-  .alert.alert-info
-    = flash[:notice]
 .container
   .col-lg-12[style="margin-bottom: 30px;"]
     h1
@@ -12,21 +9,21 @@
 
   .col-lg-12
     h4
-      | 本日の注文件数　　
-      = link_to @orders.created_today.count, admin_orders_path(created_at: @orders.created_today)
-      | 　件
+      | 本日の注文件数
+      span style="margin:30px" = link_to @orders.created_today.count, admin_orders_path(created_at: @orders.created_today)
+      | 件
   .col-lg-12
     h4
-      | 入金済 / 未発送の注文件数　　
-      = link_to @order.count, admin_orders_path(status: "not" )
-      | 　件
+      | 入金済 / 未発送の注文件数
+      span style="margin:30px" = link_to @order.count, admin_orders_path(status: "not" )
+      | 件
   - if @new_order.present? == true
     .col-lg-12
       h4
-        | 最新の注文　　
-        = link_to @new_order.created_at.to_s(:datetime_jp), admin_order_path(@new_order)
+        | 最新の注文
+        span style="margin:30px" = link_to @new_order.created_at.to_s(:datetime_jp), admin_order_path(@new_order)
   .col-lg-12
     h4
-      | 現在の有効会員数　　
-      = link_to @customers.count, admin_customers_path(is_valid: true)
-      | 　名
+      | 現在の有効会員数
+      span style="margin:30px" = link_to @customers.count, admin_customers_path(is_valid: true)
+      | 名

--- a/app/views/admin/items/_form.html.slim
+++ b/app/views/admin/items/_form.html.slim
@@ -8,20 +8,25 @@
       = f.attachment_field :item_image ,class: "hidden_file"
     .col-lg-8
       .row
-        = f.label :商品名　　　　
+        .col-md-2
+          = f.label :商品名
         = f.text_field :name,placeholder: "商品名の重複 不可"
       .row
-        = f.label :商品説明　　　
+        .col-md-2
+          = f.label :商品説明
         = f.text_area :description ,placeholder: "10文字以上 140字以内"
       .row
-        = f.label :ジャンル　　　
+        .col-md-2
+          = f.label :ジャンル
         = f.collection_select :genre_id, Genre.all, :id, :name
       .row
-        = f.label :税抜価格　　　
+        .col-md-2
+          = f.label :税抜価格
         = f.text_field :price, placeholder: "半角数字のみ"
         |  円 
       .row
-        = f.label :販売ステータス
+        .col-md-2
+          = f.label :販売ステータス
         = f.select :is_selling, [["販売中", true], ["売り切れ", false]], include_blank: "選択して下さい"
         br
   .row

--- a/app/views/admin/items/_index.html.slim
+++ b/app/views/admin/items/_index.html.slim
@@ -1,0 +1,12 @@
+- items.each do |i|
+  tr
+    td = i.id
+    td = attachment_image_tag i, :item_image , style: "width: 48px; height: 27px;"
+    td = link_to i.name, admin_item_path(i)
+    td = "#{i.price}円"
+    td = i.genre.name
+    td
+      - if i.is_selling
+        p 販売中
+      - else
+        p 販売停止中

--- a/app/views/admin/items/edit.html.slim
+++ b/app/views/admin/items/edit.html.slim
@@ -1,6 +1,3 @@
-- if flash[:notice]
-  .alert.alert-danger.text-center
-    = flash[:notice]
 .container
   .row
     .col-lg-3

--- a/app/views/admin/items/index.html.slim
+++ b/app/views/admin/items/index.html.slim
@@ -10,39 +10,13 @@
     .col-lg-offset-1.col-lg-10
       table.table
         tr.active[style="font-weight: bold"]
-          td
-            | 商品ID
-          td
-            | イメージ
-          td
-            | 商品名
-          td
-            | 税抜価格
-          td
-            | ジャンル
-          td
-            | ステータス
-      br
-      - @items.each do |i|
-        tr
-          td
-            = i.id
-          td
-            = attachment_image_tag i, :item_image , style: "width: 48px; height: 27px;"
-          td
-            = link_to i.name, admin_item_path(i)
-          td
-            = i.price
-            | 円
-          td
-            - genre = Genre.find(i.genre_id)
-            = genre.name
-          td
-            - if i.is_selling == true
-              p
-                | 販売中
-            - else
-              p
-                | 販売停止中
+          td 商品ID
+          td イメージ
+          td 商品名
+          td 税抜価格
+          td ジャンル
+          td ステータス
+        = render 'index', items: @items
+
   .col-lg-12
     = paginate @items

--- a/app/views/admin/items/new.html.slim
+++ b/app/views/admin/items/new.html.slim
@@ -1,6 +1,3 @@
-- if flash[:notice]
-  .alert.alert-danger.text-center
-    = flash[:notice]
 .container
   .row
     .col-lg-3

--- a/app/views/admins/sessions/new.html.slim
+++ b/app/views/admins/sessions/new.html.slim
@@ -1,26 +1,21 @@
-- if flash[:notice]
-  .alert.alert-info
-    = flash[:notice]
 .container
   .row
     .col-lg-5
-      h3
-        | 管理者ログイン
-  .row
-    = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+      h3 管理者ログイン
+  = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+    .row
       .col-lg-2.col-lg-offset-3
         span
           | メールアドレス
       .col-lg-3
         = f.email_field :email, autofocus: true, autocomplete: "email"
-  .row
-    .col-lg-2.col-lg-offset-3
-      span
-        | パスワード
-    .col-lg-3
-      = f.password_field :password, autocomplete: "current-password"
-  .login
     .row
-      .col-lg-3.col-lg-offset-4
+      .col-lg-2.col-lg-offset-3
+        span
+          | パスワード
+      .col-lg-3
+        = f.password_field :password, autocomplete: "current-password"
+    .login
+      .row.col-lg-3.col-lg-offset-4
         = f.submit "ログイン", class: "btn btn-primary"
-  = render "admins/shared/links"
+    = render "admins/shared/links"

--- a/app/views/customer/_sidebar.html.slim
+++ b/app/views/customer/_sidebar.html.slim
@@ -1,6 +1,4 @@
 .col-lg-2.sidebar.h-auto
-  - # 未ログイン時には表示させる
-  - # 統一
   - if customer_signed_in?
     .box
       h4

--- a/app/views/customer/customers/edit.html.slim
+++ b/app/views/customer/customers/edit.html.slim
@@ -1,7 +1,4 @@
 - provide(:title, "登録情報確認")
-- if flash[:notice]
-  .alert.alert-danger.text-center
-    = flash[:notice]
 .container
   .row
     .col-lg-2

--- a/app/views/customer/home/top.html.slim
+++ b/app/views/customer/home/top.html.slim
@@ -1,13 +1,10 @@
-- if flash[:notice]
-  .alert.alert-info.text-center
-    = flash[:notice]
 .search
   .container
     .row
       .search-form
         = form_tag(customer_items_path, method: :get) do
           span
-            | 商品名検索　▶︎　
+            | 商品名検索 ▶︎ 
           = text_field_tag :name, "", placeholder: "例：ショートケーキ"
           = submit_tag  '検索', class: "btn btn-primary"
 .eyecatch

--- a/app/views/customer/items/_cart.html.slim
+++ b/app/views/customer/items/_cart.html.slim
@@ -1,6 +1,6 @@
 - if customer_signed_in?
   = form_with model: cart_item ,local: true do |f|
-    = f.select :count,(1..20).each{ |i| p [i] } ,include_blank: ">>　個数選択"
+    = f.select :count,(1..20).each{ |i| p [i] } ,include_blank: ">>  個数選択"
     = f.hidden_field :item_id, value: @item.id
     = f.hidden_field :customer_id, value: current_customer.id
     = f.submit "カートに入れる", class: 'btn btn-primary'

--- a/app/views/customer/items/show.html.slim
+++ b/app/views/customer/items/show.html.slim
@@ -1,7 +1,4 @@
 - provide(:title, "商品詳細")
-- if flash[:notice]
-  .alert.alert-info.text-center
-    = flash[:notice]
 .container
   = render 'customer/sidebar'
   .col-lg-5

--- a/app/views/customer/mailing_addresses/edit.html.slim
+++ b/app/views/customer/mailing_addresses/edit.html.slim
@@ -1,7 +1,4 @@
 - provide(:title, "配送先編集")
-- if flash[:notice]
-  .alert.alert-danger.text-center
-    = flash[:notice]
 .container
   .mailing-form
     .col-lg-4

--- a/app/views/customer/mailing_addresses/index.html.slim
+++ b/app/views/customer/mailing_addresses/index.html.slim
@@ -1,7 +1,4 @@
 - provide(:title, "配送先一覧")
-- if flash[:notice]
-  .alert.alert-danger.text-center
-    = flash[:notice]
 .container
   .mailing-form
     .col-lg-4

--- a/app/views/customer/orders/_index.html.slim
+++ b/app/views/customer/orders/_index.html.slim
@@ -20,7 +20,7 @@ table.table.table-bordered
       td[style="line-height: 30px;"]
         | 〒 
         = order.address
-        | 　様
+        |  様
       td[style="line-height: 30px;"]
         - order_items.each do |order_item|
           = order_item.item.name

--- a/app/views/customer/orders/new.html.slim
+++ b/app/views/customer/orders/new.html.slim
@@ -1,7 +1,4 @@
 - provide(:title, "購入情報入力")
-- if flash[:notice]
-  .alert.alert-danger.text-center
-    = flash[:notice]
 .container
   .row
     .col-lg-4

--- a/app/views/customer/orders/thanks.html.slim
+++ b/app/views/customer/orders/thanks.html.slim
@@ -6,7 +6,7 @@
     = link_to customer_orders_path do
       h1.thanks-bottom.thanks
         i.fas.fa-gift
-          | 　
+          |  
           i.fas.fa-truck-moving
       h6
         | 注文内容の確認 / 配送状況の確認はこちらから可能です。

--- a/app/views/layouts/_error.html.slim
+++ b/app/views/layouts/_error.html.slim
@@ -1,0 +1,5 @@
+.row
+  - if obj.errors.any?
+    .alert.alert-danger.text-center
+      - obj.errors.full_messages.each do |message|
+        = message

--- a/app/views/layouts/_notice.html.slim
+++ b/app/views/layouts/_notice.html.slim
@@ -1,0 +1,6 @@
+- if flash[:notice]
+  .alert.alert-info.text-center
+    = flash[:notice]
+- if flash[:alert]
+  .alert.alert-danger.text-center
+    = flash[:alert]

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,5 +10,6 @@ html
     = favicon_link_tag('favicon.ico')
   body
     = render 'layouts/header'
+    = render 'layouts/notice'
     = yield
     = render 'layouts/footer'


### PR DESCRIPTION
全角スペースが多用されていたので半角スペースに代用したり
マージンを適用させたりしました。
本当は全部にマージンかけた方がいいと思ったのですが、
共通スタイルの命名を考えるのは別のブランチでやりたいのでまた改めます！

（どうしても多用されていたflash[:notice]の記載が気になったのでパーシャル化しました）